### PR TITLE
Updated AWS-SDK-PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.5.0",
         "aws/aws-sdk-php": "3.*",
-        "irap/emailers" : "2.*"
+        "irap/emailers" : "2.*",
+        "ext-xml" : "1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.5.0",
         "aws/aws-sdk-php": "3.*",
-        "irap/emailers" : "1.3.*"
+        "irap/emailers" : "2.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "aws/aws-sdk-php": "3.24.*",
+        "aws/aws-sdk-php": "3.*",
         "irap/emailers" : "1.3.*"
     },
     "autoload": {


### PR DESCRIPTION
Updated AWS-SDK-PHP dependency to 3.* because the library is bug-fixed too fast for us to keep up with.